### PR TITLE
Ar/woodbury size

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PDMatsExtras"
 uuid = "2c7acb1b-7338-470f-b38f-951d2bcb9193"
 authors = ["Invenia Technical Computing"]
-version = "2.6.0"
+version = "2.6.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/psd_mat.jl
+++ b/src/psd_mat.jl
@@ -103,6 +103,7 @@ Overwrite `r` with the value of the quadratic form defined by `inv(a)` applied c
 """
 PDMats.invquad!(r::AbstractArray, a::PSDMat, x::StridedMatrix) = PDMats.colwise_dot!(r, x, a.mat \ x)
 
+Base.size(a::PSDMat) = (a.dim, a.dim)
 
 ### tri products
 

--- a/src/woodbury_pd_mat.jl
+++ b/src/woodbury_pd_mat.jl
@@ -87,6 +87,7 @@ function PDMats.unwhiten!(r::DenseVecOrMat, W::WoodburyPDMat{<:Real}, x::DenseVe
     return unwhiten!(r, PDMat(Symmetric(Matrix(W))), x)
 end
 
+Base.size(a::WoodburyPDMat) = (size(a.A)[1], size(a.A)[1])
 
 
 # NOTE: the parameterisation to scale up the Woodbury matrix is not unique. Here we

--- a/test/psd_mat.jl
+++ b/test/psd_mat.jl
@@ -65,6 +65,7 @@ end
         @test isa(Σ, Matrix{Float64})
         @test length(μ) == d
         @test size(Σ) == (d, d)
+        @test size(Σ, 1) == d 
         @test var(g)     ≈ diag(Σ)
         @test entropy(g) ≈ 0.5 * logdet(2π * ℯ * Σ)
         ldcov = logdetcov(g)

--- a/test/woodbury_pd_mat.jl
+++ b/test/woodbury_pd_mat.jl
@@ -22,6 +22,9 @@
     @testset "Basic functionality" begin
         # Checks getindex works.
         @test all(isapprox.(W, W_dense))
+        @test size(W) == size(W_dense)
+        @test size(W, 1) == size(W_dense, 1)
+        @test size(W, 2) == size(W_dense, 2)
     end
 
     @testset "unwhiten!" begin
@@ -81,4 +84,5 @@
             return logpdf(Distributions.GenericMvTDist(α, m, W), x)
         end
     end
+
 end


### PR DESCRIPTION
PDMats (0.11.14) dropped the generic size method in https://github.com/JuliaStats/PDMats.jl/pull/170 in order to deprecate `dim`. This broke subtypes of `AbstractPDMat` that we use here. 

This should fix our implementatations.

It would cause: 

```
using LinearAlgebra
using PDMatsExtras

A = randn(4, 2); D = Diagonal(rand(2,)); S = Diagonal(rand(4,))
4×4 Diagonal{Float64, Vector{Float64}}:
 0.880599   ⋅         ⋅         ⋅ 
  ⋅        0.859429   ⋅         ⋅ 
  ⋅         ⋅        0.210842   ⋅ 
  ⋅         ⋅         ⋅        0.699712

W = WoodburyPDMat(A, D, S)
Error showing value of type WoodburyPDMat{Float64, Matrix{Float64}, Diagonal{Float64, Vector{Float64}}, Diagonal{Float64, Vector{Float64}}}:
```

and similar for `PSDMat` 
