### PR TITLE
Improve complexity of `getindex`

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "blue"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PDMatsExtras"
 uuid = "2c7acb1b-7338-470f-b38f-951d2bcb9193"
 authors = ["Invenia Technical Computing"]
-version = "2.6.1"
+version = "2.6.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/woodbury_pd_mat.jl
+++ b/src/woodbury_pd_mat.jl
@@ -47,6 +47,8 @@ Base.Matrix(W::WoodburyPDMat) = W.A * W.D * W.A' + W.S
 Base.Array(W::WoodburyPDMat) = Matrix(W)
 
 function Base.getindex(W::WoodburyPDMat, i1::Integer, i2::Integer)
+    # Construct only the element we request. This avoids the likes of:
+    #   https://github.com/invenia/PDMatsExtras.jl/issues/30
     return @views W.A[i1, :]' * W.D * W.A[i2, :] + W.S[i1, i2]
 end
 

--- a/src/woodbury_pd_mat.jl
+++ b/src/woodbury_pd_mat.jl
@@ -42,10 +42,13 @@ WoodburyPDMat{T, TA, TD, TS}(vals...) where {T, TA, TD, TS} = WoodburyPDMat(vals
 
 PDMats.dim(W::WoodburyPDMat) = size(W.A, 1)
 
-# Convesion method. Primarily useful for testing purposes.
+# Conversion method. Primarily useful for testing purposes.
 Base.Matrix(W::WoodburyPDMat) = W.A * W.D * W.A' + W.S
+Base.Array(W::WoodburyPDMat) = Matrix(W)
 
-Base.getindex(W::WoodburyPDMat, inds...) = getindex(Matrix(W), inds...)
+function Base.getindex(W::WoodburyPDMat, i1::Integer, i2::Integer)
+    return @views W.A[i1, :]' * W.D * W.A[i2, :] + W.S[i1, i2]
+end
 
 function validate_woodbury_arguments(A, D, S)
     if size(A, 1) != size(S, 1)

--- a/src/woodbury_pd_mat.jl
+++ b/src/woodbury_pd_mat.jl
@@ -45,12 +45,25 @@ PDMats.dim(W::WoodburyPDMat) = size(W.A, 1)
 # Conversion method. Primarily useful for testing purposes.
 Base.Matrix(W::WoodburyPDMat) = W.A * W.D * W.A' + W.S
 Base.Array(W::WoodburyPDMat) = Matrix(W)
+Base.collect(W::WoodburyPDMat) = Matrix(W)
 
 function Base.getindex(W::WoodburyPDMat, i1::Integer, i2::Integer)
     # Construct only the element we request. This avoids the likes of:
     #   https://github.com/invenia/PDMatsExtras.jl/issues/30
     return @views W.A[i1, :]' * W.D * W.A[i2, :] + W.S[i1, i2]
 end
+
+function _get_row_or_col(W::WoodburyPDMat, i::Integer)
+    # Get a vector representing row i.
+    # This is identical to column i, since `W` is always symmetric.
+    result = W.A * W.D * @view W.A[i, :]
+    result .+= @view W.S[i, :]
+    return result
+end
+
+Base.getindex(W::WoodburyPDMat, i1::Integer, ::Colon) = _get_row_or_col(W, i1)
+Base.getindex(W::WoodburyPDMat, ::Colon, i2::Integer) = _get_row_or_col(W, i2)
+Base.getindex(W::WoodburyPDMat, ::Colon) = vec(Matrix(W))
 
 function validate_woodbury_arguments(A, D, S)
     if size(A, 1) != size(S, 1)

--- a/test/woodbury_pd_mat.jl
+++ b/test/woodbury_pd_mat.jl
@@ -31,6 +31,10 @@
             @test W[:, i] ≈ W_dense[:, i]
         end
 
+        @test W[:] ≈ W_dense[:]
+
+        @test collect(W) ≈ collect(W_dense)
+
         @test size(W) == size(W_dense)
         @test size(W, 1) == size(W_dense, 1)
         @test size(W, 2) == size(W_dense, 2)

--- a/test/woodbury_pd_mat.jl
+++ b/test/woodbury_pd_mat.jl
@@ -22,6 +22,15 @@
     @testset "Basic functionality" begin
         # Checks getindex works.
         @test all(isapprox.(W, W_dense))
+        @test all((W[i] ≈ W_dense[i] for i in 1:length(W)))
+
+        for i in size(W, 1)
+            @test W[i, :] ≈ W_dense[i, :]
+        end
+        for i in size(W, 2)
+            @test W[:, i] ≈ W_dense[:, i]
+        end
+
         @test size(W) == size(W_dense)
         @test size(W, 1) == size(W_dense, 1)
         @test size(W, 2) == size(W_dense, 2)

--- a/test/woodbury_pd_mat.jl
+++ b/test/woodbury_pd_mat.jl
@@ -22,17 +22,25 @@
     @testset "Basic functionality" begin
         # Checks getindex works.
         @test all(isapprox.(W, W_dense))
-        @test all((W[i] ≈ W_dense[i] for i in 1:length(W)))
+
+        for i in 1:length(W)
+            @test W[i] ≈ W_dense[i]
+            @test W[1:i] ≈ W_dense[1:i]
+        end
 
         for i in size(W, 1)
             @test W[i, :] ≈ W_dense[i, :]
+            @test W[1:i, :] ≈ W_dense[1:i, :]
         end
         for i in size(W, 2)
             @test W[:, i] ≈ W_dense[:, i]
+            @test W[:, 1:i] ≈ W_dense[:, 1:i]
         end
 
-        @test W[:] ≈ W_dense[:]
+        # Test particular case of two ranges.
+        @test W[2:3, 1:2] ≈ W_dense[2:3, 1:2]
 
+        @test W[:] ≈ W_dense[:]
         @test collect(W) ≈ collect(W_dense)
 
         @test size(W) == size(W_dense)


### PR DESCRIPTION
Previously, `getindex` constructed the full dense matrix. This gets expensive, as it is used when e.g. forming a string representation of the array.

Now we compute only the part that is necessary.

Closes #30 