### PR TITLE
Ar/whiten

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PDMatsExtras"
 uuid = "2c7acb1b-7338-470f-b38f-951d2bcb9193"
 authors = ["Invenia Technical Computing"]
-version = "2.6.2"
+version = "2.6.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/woodbury_pd_mat.jl
+++ b/src/woodbury_pd_mat.jl
@@ -105,6 +105,12 @@ function PDMats.unwhiten!(r::DenseVecOrMat, W::WoodburyPDMat{<:Real}, x::DenseVe
     return unwhiten!(r, PDMat(Symmetric(Matrix(W))), x)
 end
 
+# This just similarly densifies
+PDMats.whiten(W::WoodburyPDMat, x::AbstractVecOrMat) = PDMats.whiten(PDMat(Symmetric(Matrix(W))), x)
+PDMats.whiten!(W::WoodburyPDMat, x::AbstractVecOrMat) = PDMats.whiten!(PDMat(Symmetric(Matrix(W))), x)
+PDMats.whiten!(r::AbstractVecOrMat, W::WoodburyPDMat, x::AbstractVecOrMat) = PDMats.whiten!(r, PDMat(Symmetric(Matrix(W))), x)
+
+
 Base.size(a::WoodburyPDMat) = (size(a.A)[1], size(a.A)[1])
 
 

--- a/test/woodbury_pd_mat.jl
+++ b/test/woodbury_pd_mat.jl
@@ -50,6 +50,13 @@
 
     @testset "unwhiten!" begin
         @test PDMats.unwhiten!(similar(x), W, x) ≈ PDMats.unwhiten!(similar(x), W_dense, x)
+        
+    end
+
+    @testset "whiten" begin
+        @test PDMats.whiten(W, x) ≈ PDMats.whiten(W_dense, x)
+        @test PDMats.whiten!(similar(x), W, x) ≈ PDMats.whiten!(similar(x), W_dense, x)
+        @test PDMats.whiten!(W, x) ≈ PDMats.whiten!(W_dense, x)
     end
 
     @testset "logdet" begin


### PR DESCRIPTION
Adds `whiten` for WoodburyPDMat. 

It doesn't do anything special other than densifies and calls `PDMats` unwhiten. Without this, we'll hit a cholesky error as `PDMats` tries to call `cholesky` on the `WoodburyPDMat`. 

```
julia> whiten(W, x)
ERROR: MethodError: no method matching cholesky(::WoodburyPDMat{Float64, Matrix{Float64}, Diagonal{Float64, Vector{Float64}}, Diagonal{Float64, Vector{Float64}}})
```