### PR TITLE
Fix pivoted order in whiten & unwhiten

### DIFF
--- a/src/psd_mat.jl
+++ b/src/psd_mat.jl
@@ -76,13 +76,17 @@ LinearAlgebra.kron(a::PSDMat, b::AbstractPDMat) = PSDMat(kron(a.mat, Matrix(b)))
 function PDMats.whiten!(r::StridedVecOrMat, a::PSDMat, x::StridedVecOrMat)
     cf = a.chol.U
     v = PDMats._rcopy!(r, x)
-    istriu(cf) ? ldiv!(transpose(cf), v) : ldiv!(cf, v)
+    view_v = v isa StridedVector ? view(v, a.chol.p) : view(v, a.chol.p, :)
+    istriu(cf) ? ldiv!(transpose(cf), view_v) : ldiv!(cf, view_v)
+    return v
 end
 
 function PDMats.unwhiten!(r::StridedVecOrMat, a::PSDMat, x::StridedVecOrMat)
     cf = a.chol.U
     v = PDMats._rcopy!(r, x)
-    istriu(cf) ? lmul!(transpose(cf), v) : lmul!(cf, v)
+    view_v = v isa StridedVector ? view(v, a.chol.p) : view(v, a.chol.p, :)
+    istriu(cf) ? lmul!(transpose(cf), view_v) : lmul!(cf, view_v)
+    return v
 end
 
 

--- a/test/psd_mat.jl
+++ b/test/psd_mat.jl
@@ -48,6 +48,27 @@ end
         )
         pdtest_kron(C, C.mat, verbose)
     end
+
+    @testset "whiten! & unwhiten! respect permutation of CholeskyPivoted" begin
+
+        # test that whiten! & unwhiten! respect the permutation of CholeskyPivoted
+        mat = [
+            1. 0  0
+            0  3. 0
+            0  0  2.
+        ]
+        pd  = PDMat(mat)
+        psd = PSDMat(mat)
+        # psd.chol.p == [2, 3, 1]
+
+        x = ones(size(mat, 1))
+        @test whiten!(  similar(x), pd, x) ≈ whiten!(  similar(x), psd, x)
+        @test unwhiten!(similar(x), pd, x) ≈ unwhiten!(similar(x), psd, x)
+
+        x = ones(size(mat, 1), 5)
+        @test whiten!(  similar(x), pd, x) ≈ whiten!(  similar(x), psd, x)
+        @test unwhiten!(similar(x), pd, x) ≈ unwhiten!(similar(x), psd, x)
+    end
 end
 
 @testset "Degenerate MvNormal" begin
@@ -65,7 +86,7 @@ end
         @test isa(Σ, Matrix{Float64})
         @test length(μ) == d
         @test size(Σ) == (d, d)
-        @test size(Σ, 1) == d 
+        @test size(Σ, 1) == d
         @test var(g)     ≈ diag(Σ)
         @test entropy(g) ≈ 0.5 * logdet(2π * ℯ * Σ)
         ldcov = logdetcov(g)


### PR DESCRIPTION
This bug popped up in Slack when `rand(Distributions.MvNormal(PSDMat(...)))` seemingly returned permuted samples. This PR is a proposal to fix that.

on master
```julia
using PDMats, PDMatsExtras

mat = [1.; 0 ;; 0 ; 2]
pd  = PDMat(mat)
psd = PSDMat(mat)
psd.chol.p # [2, 1]

x = ones(2)
whiten!(similar(x), pd,  x)
whiten!(similar(x), psd, x)

x = ones(2)
unwhiten!(similar(x), pd,  x)
unwhiten!(similar(x), psd, x)

x = ones(2, 3)
whiten!(similar(x), pd,  x) 
whiten!(similar(x), psd, x)

x = ones(2, 3)
unwhiten!(similar(x), pd,  x) 
unwhiten!(similar(x), psd, x)
```
For `PDMat` this returns e.g.,
```julia
2-element Vector{Float64}:
 1.0
 0.7071067811865475
```
but for `PSDMat` this returns
```julia
2-element Vector{Float64}:
 0.7071067811865475
 1.0
```
because the pivot in `psd.chol.p` is ignored. 

This PR fixes this and adds a test.




Comments, feedback, and other suggestions are welcome!