### PR TITLE
Mimic constructor from PDMats.jl so that PSDMat(<:Matrix{<:Integer}) does not throw

### DIFF
--- a/src/psd_mat.jl
+++ b/src/psd_mat.jl
@@ -24,7 +24,7 @@ struct PSDMat{T<:Real,S<:AbstractMatrix} <: AbstractPDMat{T}
 end
 
 function PSDMat(mat::AbstractMatrix, chol::CholType{T,S}) where {T,S}
-    d = size(mat, 1)
+    d = LinearAlgebra.checksquare(mat)
     size(chol, 1) == d ||
         throw(DimensionMismatch("Dimensions of mat and chol are inconsistent."))
     PSDMat{T, S}(d, convert(S, mat), chol)

--- a/src/psd_mat.jl
+++ b/src/psd_mat.jl
@@ -23,11 +23,11 @@ struct PSDMat{T<:Real,S<:AbstractMatrix} <: AbstractPDMat{T}
     PSDMat{T,S}(m::AbstractMatrix{T},c::CholType{T,S}) where {T,S} = new{T, S}(m, c)
 end
 
-function PSDMat(mat::AbstractMatrix, chol::CholType)
-    d = LinearAlgebra.checksquare(mat)
+function PSDMat(mat::AbstractMatrix, chol::CholType{T,S}) where {T,S}
+    d = size(mat, 1)
     size(chol, 1) == d ||
         throw(DimensionMismatch("Dimensions of mat and chol are inconsistent."))
-    PSDMat{eltype(mat),typeof(mat)}(mat, chol)
+    PSDMat{T, S}(d, convert(S, mat), chol)
 end
 
 PSDMat(mat::Matrix) = PSDMat(mat, cholesky(mat, VERSION >= v"1.8.0-rc1" ? RowMaximum() : Val(true); check=false))

--- a/test/psd_mat.jl
+++ b/test/psd_mat.jl
@@ -69,6 +69,20 @@ end
         @test whiten!(  similar(x), pd, x) ≈ whiten!(  similar(x), psd, x)
         @test unwhiten!(similar(x), pd, x) ≈ unwhiten!(similar(x), psd, x)
     end
+
+    @testset "Constructing from Matrix{<:Integer} works" begin
+
+        m = [
+            1   0
+            0   1
+        ]
+
+        for type in (UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt, Int)
+            @test PSDMat{Float64, Matrix{Float64}} == typeof(PSDMat(type.(m)))
+        end
+
+    end
+
 end
 
 @testset "Degenerate MvNormal" begin


### PR DESCRIPTION
Per this [discourse post](https://discourse.julialang.org/t/would-slowing-julias-release-cadence-improve-ecosystem-quality/103114/99), the following throws:
```julia
PSDMat([0 0; 0 1])
ERROR: MethodError: no method matching PSDMat{Int64, Matrix{Int64}}(::Int64, ::Matrix{Int64}, ::CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}})
```
It also used to throw in PDMats.jl, but that was fixed in https://github.com/JuliaStats/PDMats.jl/pull/117. This PR copies the changes in that PR and adds a small test.

Technically this is probably a breaking change, but PDMats.jl merged that PR in a patch release so ¯\\_(ツ)_/¯ 