### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,6 @@
 name: CI
 # Run on master, tags, or any pull request
 on:
-  schedule:
-    - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
   push:
     branches: [master]
     tags: ["*"]
@@ -29,11 +27,6 @@ jobs:
             arch: x86
           - os: windows-latest
             arch: x86
-        include:
-          # Add a 1.5 job because that's what Invenia actually uses
-          - os: ubuntu-latest
-            version: 1.5
-            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -57,22 +50,6 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
-
-  slack:
-    name: Notify Slack Failure
-    needs: test
-    runs-on: ubuntu-latest
-    if: always() && github.event_name == 'schedule'
-    steps:
-      - uses: technote-space/workflow-conclusion-action@v2
-      - uses: voxmedia/github-action-slack-notify-build@v1
-        if: env.WORKFLOW_CONCLUSION == 'failure'
-        with:
-          channel: nightly-rse
-          status: FAILED
-          color: danger
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.RSE_SLACK_BOT_TOKEN }}
 
   docs:
     name: Documentation


### PR DESCRIPTION
Gets rid of the sechedule job since
1. no-one is monitoring them anymore
2. it makes github disable our CI

Gets rid of the slack notifier cos noone is watching it anymore

Gets rid of the Julia 1.5 tests as that is no longer in use